### PR TITLE
feat: add Kanban column management and column_id support

### DIFF
--- a/src/ticktick_mcp/tools/projects.py
+++ b/src/ticktick_mcp/tools/projects.py
@@ -193,3 +193,108 @@ def register(mcp: FastMCP) -> None:
         pid = await _resolve_project_id(client, project)
         await client.v1_delete(f"/project/{pid}")
         return f"Project {project} deleted"
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        }
+    )
+    async def list_columns(
+        ctx: Context,
+        project: str,
+    ) -> list[dict[str, Any]]:
+        """List all Kanban columns (sections) in a project.
+
+        Returns column IDs, names, and sort orders. Only meaningful for
+        projects in kanban view mode.
+
+        Args:
+            project: Project name or ID. Supports fuzzy matching.
+        """
+        client = _get_client(ctx)
+        pid = await _resolve_project_id(client, project)
+        data = await client.v1_get(f"/project/{pid}/data")
+        columns = data.get("columns", [])
+        return [{"id": c["id"], "name": c.get("name", ""), "sortOrder": c.get("sortOrder", 0)} for c in columns]
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": False,
+            "openWorldHint": True,
+        }
+    )
+    async def add_column(
+        ctx: Context,
+        project: str,
+        name: str,
+    ) -> dict[str, Any]:
+        """Add a new Kanban column (section) to a project.
+
+        The project should be in kanban view mode.
+
+        Args:
+            project: Project name or ID. Supports fuzzy matching.
+            name: Name for the new column.
+        """
+        client = _get_client(ctx)
+        pid = await _resolve_project_id(client, project)
+        body = {"projectId": pid, "name": name}
+        return await client.v1_post(f"/column", body)
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        }
+    )
+    async def rename_column(
+        ctx: Context,
+        project: str,
+        column_id: str,
+        name: str,
+    ) -> dict[str, Any]:
+        """Rename a Kanban column (section).
+
+        Args:
+            project: Project name or ID. Supports fuzzy matching.
+            column_id: The column ID to rename. Use list_columns to get IDs.
+            name: New name for the column.
+        """
+        client = _get_client(ctx)
+        pid = await _resolve_project_id(client, project)
+        body = {"projectId": pid, "name": name}
+        return await client.v1_post(f"/column/{column_id}", body)
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        }
+    )
+    async def delete_column(
+        ctx: Context,
+        project: str,
+        column_id: str,
+    ) -> str:
+        """Delete a Kanban column (section) from a project.
+
+        Tasks in the column are NOT deleted — they become unassigned.
+        This action cannot be undone.
+
+        Args:
+            project: Project name or ID. Supports fuzzy matching.
+            column_id: The column ID to delete. Use list_columns to get IDs.
+        """
+        client = _get_client(ctx)
+        await _resolve_project_id(client, project)
+        await client.v1_delete(f"/column/{column_id}")
+        return f"Column {column_id} deleted"

--- a/src/ticktick_mcp/tools/tasks.py
+++ b/src/ticktick_mcp/tools/tasks.py
@@ -252,6 +252,7 @@ def register(mcp: FastMCP) -> None:
         clear_due: bool = False,
         clear_start: bool = False,
         timezone: str | None = None,
+        column_id: str | None = None,
     ) -> dict[str, Any]:
         """Update an existing task.
 
@@ -270,6 +271,7 @@ def register(mcp: FastMCP) -> None:
             clear_due: Set to true to remove the due date.
             clear_start: Set to true to remove the start date.
             timezone: IANA timezone for date interpretation.
+            column_id: Move task to a Kanban column (section) by its ID. Use list_columns to get IDs.
         """
         client = _get_client(ctx)
         pid = await _resolve_project_id(client, project)
@@ -305,6 +307,9 @@ def register(mcp: FastMCP) -> None:
 
         if timezone:
             body["timeZone"] = timezone
+
+        if column_id is not None:
+            body["columnId"] = column_id
 
         return await client.v1_post(f"/task/{task_id}", body)
 


### PR DESCRIPTION
## Summary

- Add `column_id` parameter to `edit_task` for moving tasks between Kanban columns programmatically
- Add `list_columns` tool to retrieve all columns (sections) with IDs and names
- Add `add_column`, `rename_column`, `delete_column` tools for full Kanban board management

## Motivation

Currently there's no way to manage Kanban columns (sections) or move tasks between them via MCP. This forces users to switch to the TickTick UI for basic Kanban operations, breaking automation workflows.

## Details

### `edit_task` — new `column_id` parameter

The TickTick API accepts `columnId` in task update payloads (`POST /open/v1/task/{id}`). This was verified experimentally — the field is returned in GET responses and accepted in POST bodies, even though it's not in the official docs.

### New tools in `projects.py`

| Tool | Endpoint | Purpose |
|------|----------|---------|
| `list_columns(project)` | `GET /open/v1/project/{id}/data` | List all Kanban columns with IDs |
| `add_column(project, name)` | `POST /open/v1/column` | Create a new column |
| `rename_column(project, column_id, name)` | `POST /open/v1/column/{id}` | Rename a column |
| `delete_column(project, column_id)` | `DELETE /open/v1/column/{id}` | Delete a column (tasks preserved) |

### Note on column endpoints

The `/column` endpoints are not officially documented but follow the same pattern as other v1 endpoints. `list_columns` uses the existing documented `/project/{id}/data` endpoint which already returns column data. The `add_column`, `rename_column`, and `delete_column` endpoints are inferred from the API patterns and may need validation — if they don't work, `list_columns` + `edit_task` with `column_id` are the essential features (both verified working).

## Test plan

- [x] Verified `edit_task` with `column_id` moves tasks between Kanban columns
- [x] Verified `list_columns` returns correct column IDs and names via `/project/{id}/data`
- [ ] `add_column`, `rename_column`, `delete_column` — inferred endpoints, need testing with live API